### PR TITLE
Update lexicon.py

### DIFF
--- a/my-hard-way/myhardway/lexicon.py
+++ b/my-hard-way/myhardway/lexicon.py
@@ -27,7 +27,7 @@ def scan(sentence):
     pairs = []
     for word in sentence.split():
         try:
-            pairs.append(('number', str(int(word))))
+            pairs.append(('number', int(word)))
         except ValueError:
             category = words.get(word, None)
             if not category:


### PR DESCRIPTION
Changed str(int(word)) to int(word) on line 30 so that this code works with the test example provided in the textbook.

Lines 34-38 from lexicon_tests.py are below. Note assertion is that 'number' is equal to an integer, not the string of an integer.

def test_numbers():
    assert_equal(lexicon.scan("1234"), [('number', 1234)])
    result = lexicon.scan("3 91234")
    assert_equal(result, [('number', 3),
                          ('number', 91234)])